### PR TITLE
ALBS-50 Font/color improvements

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -26,7 +26,6 @@
     <q-drawer
       v-if="onBuildFeed"
       v-model="rightDrawerOpen"
-      show-if-above
       bordered
       class="bg-grey-1"
       side="right"

--- a/src/pages/Build.vue
+++ b/src/pages/Build.vue
@@ -142,10 +142,10 @@
                           icon="link" v-if="linked_builds">
           <q-card>
             <q-card-section v-for="linked_build in linked_builds" :key="linked_build">
-              <q-item :to="`/build/${linked_build}`">
-                <q-item-section>
-                  {{ linked_build }}
-                </q-item-section>
+              <q-item>
+                 <router-link :to="`/build/${linked_build}`">
+                  Build {{ linked_build }}
+                 </router-link>
               </q-item>
             </q-card-section>
           </q-card>
@@ -156,24 +156,24 @@
                           icon="settings" v-if="mock_options">
           <q-card>
             <q-card-section>
-              <q-item-section v-if="mock_options.with" style="font-size: 12pt; letter-spacing: 1pt;">
+              <q-item-section v-if="mock_options.with" style="font-size: 10pt; letter-spacing: 1pt;">
                 --with '{{ mock_options.with.join(' ') }}'
               </q-item-section>
-              <q-item-section v-if="mock_options.without" style="font-size: 12pt; letter-spacing: 1pt;">
+              <q-item-section v-if="mock_options.without" style="font-size: 10pt; letter-spacing: 1pt;">
                 --without '{{ mock_options.without.join(' ') }}'
               </q-item-section>
-              <q-item-section v-if="mock_options.target_arch" style="font-size: 12pt; letter-spacing: 1pt;">
+              <q-item-section v-if="mock_options.target_arch" style="font-size: 10pt; letter-spacing: 1pt;">
                 --target '{{ mock_options.target_arch }}'
               </q-item-section>
-              <q-item-section v-if="mock_options.yum_exclude" style="font-size: 12pt; letter-spacing: 1pt;">
+              <q-item-section v-if="mock_options.yum_exclude" style="font-size: 10pt; letter-spacing: 1pt;">
                 -x '{{ mock_options.yum_exclude.join(' ') }}'
               </q-item-section>
-              <q-item-section v-if="mock_options.definitions" style="font-size: 12pt; letter-spacing: 1pt;">
+              <q-item-section v-if="mock_options.definitions" style="font-size: 10pt; letter-spacing: 1pt;">
                 <q-item-section v-for="name in Object.keys(mock_options.definitions)" :key="name">
                   --define '{{ name }} {{ mock_options.definitions[name] }}'
                 </q-item-section>
               </q-item-section>
-              <q-item-section v-if="mock_options.module_enable" style="font-size: 12pt; letter-spacing: 1pt;">
+              <q-item-section v-if="mock_options.module_enable" style="font-size: 10pt; letter-spacing: 1pt;">
                 enabled modules : {{ mock_options.module_enable.join(' ') }}
               </q-item-section>
             </q-card-section>

--- a/src/pages/BuildFeed.vue
+++ b/src/pages/BuildFeed.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-page class="q-pl-lg q-pt-md q-pr-lg">
+  <q-page class="q-px-lg q-pt-lg">
     <div>
       <BuildFeedItem
         v-for="build in builds"

--- a/src/pages/BuildPlanner.vue
+++ b/src/pages/BuildPlanner.vue
@@ -51,7 +51,7 @@
         <q-list v-if="buildPlan.linked_builds.length" style="min-width: 250px; max-width: 300px;">
           <q-item v-for="linkedBuild in buildPlan.linked_builds" :key="linkedBuild">
             <q-item-section>
-              <router-link :to="`/build/${linkedBuild}`">
+              <router-link :to="`/build/${linkedBuild}`" target="_blank">
                 {{ linkedBuild }}
               </router-link>
             </q-item-section>


### PR DESCRIPTION
- Add a little bit empty space on top of build feed
- Change linked builds under build to look like link, and not like text
- Decrease Mock options font size under build
- Remove automatic appearance of the build search drawer
- Add ability to open linked builds in a new tab