### PR TITLE
ALBS-373 Add error during create/update release

### DIFF
--- a/src/pages/CreateRelease.vue
+++ b/src/pages/CreateRelease.vue
@@ -39,6 +39,7 @@
 
 <script>
 import { defineComponent, ref } from 'vue'
+import { Notify } from 'quasar'
 import BuildSelectionForm from 'components/BuildSelectionForm.vue'
 import PackageLocationSelectionForm from 'components/PackageLocationSelectionForm.vue'
 
@@ -64,6 +65,14 @@ export default defineComponent({
                 })
                 .catch(error => {
                     console.log(error)
+                    Notify.create({
+                        message: `${error.response.status}: ${error.response.statusText}`,
+                        type: 'negative',
+                        actions: [
+                            { label: 'Dismiss', color: 'white', handler: () => {} }
+                        ]
+                    })
+                    this.onPreviousStep()
                 })
         },
         updateRelease (request_body) {
@@ -74,6 +83,14 @@ export default defineComponent({
                 })
                 .catch(error => {
                     console.log(error)
+                    Notify.create({
+                        message: `${error.response.status}: ${error.response.statusText}`,
+                        type: 'negative',
+                        actions: [
+                            { label: 'Dismiss', color: 'white', handler: () => {} }
+                        ]
+                    })
+                    this.onPreviousStep()
                 }) 
         },
         saveState (state){


### PR DESCRIPTION
If create/update release will fall, we doesn’t see error and package location screen still show loading, that’s incorrect