### PR TITLE
ALBS-429 Remove access to the functional after logout

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -92,6 +92,7 @@ const linksList = [
 ];
 
 import { defineComponent, ref } from 'vue'
+import { LocalStorage } from 'quasar'
 
 export default defineComponent({
   name: 'MainLayout',
@@ -103,6 +104,17 @@ export default defineComponent({
     onBuildFeed () {
       return this.$route.name && this.$route.name.startsWith('BuildFeed')
     }
+  },
+  mounted() {
+    window.addEventListener('storage', () => {
+      let user = LocalStorage.getItem('user')
+      if (user) {
+        store.commit('users/updateSelf', user)
+        this.$router.go()
+      } else {
+        this.onLogout()
+      }
+    })
   },
   setup () {
     const leftDrawerOpen = ref(false)


### PR DESCRIPTION
Issue description: If I opened a few tabs (add new release or something like this) before logout.
I was able to release some package when I had logged out in another tab.
The tab was opened before logout.