### PR TITLE
ALBS-634 Add warnings when creating a new build

### DIFF
--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -87,7 +87,7 @@ module.exports = configure(function (ctx) {
       config: {
         brand: {
           primary: '#0069da',
-          secondary: '#74a57b',
+          secondary: '#2e7d32',
           accent: '#722865',
 
           dark: '#082336',

--- a/src/pages/BuildPlanner.vue
+++ b/src/pages/BuildPlanner.vue
@@ -15,21 +15,23 @@
 
         <q-select v-model="product"
                   :options="buildProducts"
-                  label="Product*:"
+                  label="Product:"
                   clearable
                   style="min-width: 250px; max-width: 300px"
                   ref="selectProduct"
                   :rules="[val => !!val || 'Product is required']"
+                  :hint="!product ? 'Product is required' : null"
         />
 
         <q-select v-model="buildPlan.platforms"
                   :options="buildPlatforms"
                   multiple
                   use-chips
-                  label="Build platform(s)*:"
+                  label="Build platform(s):"
                   style="min-width: 250px; max-width: 300px"
                   ref="selectPlatforms"
                   :rules="[val => !(val.length < 1) || 'Platforms is required']"
+                  :hint="buildPlan.platforms.length === 0 ? 'Platforms is required' : null"
         >
           <template v-slot:option="scope">
             <q-item v-bind="scope.itemProps">
@@ -46,10 +48,11 @@
                     :options="platform.archList"
                     multiple
                     chips
-                    :label="`${platform.label} selected architectures*`"
+                    :label="`${platform.label} selected architectures`"
                     style="min-width: 250px; max-width: 300px"
                     ref="selectArches"
                     :rules="[val => checkArchError(val) || 'Architectures is required']"
+                    :hint="!checkArchError(platformArches[platform.label]) ? 'Architectures is required' : null"
           />
         </template>
 


### PR DESCRIPTION
Add warning saying build product, platform, and architecture are required to create a new build. Currently, when creating a new build it allows a user to proceed with adding a project after adding a product and a platform. 
Existing behavior: when adding a platform, there will appear a “blue pencil” saying you can proceed, but you cant. when also choosing a product, you’ll be able to proceed and add projects. Though, the build won’t be created as no architectures were selected. There’s no warning about that.

Expected behavior: a “blue pencil” sign should appear only after choosing a product, a platform and architecture/s. If one of them wasn’t selected, there should be a warning for that.