### PR TITLE
ALBS-667 Show only projects on the Release Feed

### DIFF
--- a/src/components/PackageLocationSelectionForm.vue
+++ b/src/components/PackageLocationSelectionForm.vue
@@ -560,8 +560,7 @@ export default defineComponent({
                     name: moduleLocation.name,
                     stream: moduleLocation.stream,
                     template: moduleLocation.template,
-                    version: moduleLocation.version,
-                    source: moduleLocation.source
+                    version: moduleLocation.version
                 }
                 this.archs.forEach(arch => {
                     if (moduleLocation[arch] && this.repositories[arch] && moduleLocation.destination) {

--- a/src/components/PackageLocationSelectionForm.vue
+++ b/src/components/PackageLocationSelectionForm.vue
@@ -560,7 +560,8 @@ export default defineComponent({
                     name: moduleLocation.name,
                     stream: moduleLocation.stream,
                     template: moduleLocation.template,
-                    version: moduleLocation.version
+                    version: moduleLocation.version,
+                    source: moduleLocation.source
                 }
                 this.archs.forEach(arch => {
                     if (moduleLocation[arch] && this.repositories[arch] && moduleLocation.destination) {
@@ -590,7 +591,8 @@ export default defineComponent({
                     sha256: packLocation.sha256,
                     cas_hash: packLocation.cas_hash,
                     version: packLocation.version,
-                    build_id: packLocation.build_id
+                    build_id: packLocation.build_id,
+                    source: packLocation.source
                 }
                 this.archs.forEach(arch => {
                     if (packLocation[arch] && this.repositories[arch] && packLocation.destination) {

--- a/src/pages/ReleaseFeed.vue
+++ b/src/pages/ReleaseFeed.vue
@@ -259,29 +259,41 @@ export default defineComponent({
             let packages = []
             let setPackages = new Set()
             plan.packages.forEach(pack => {
-                
-                if (pack.package.arch === 'src') {
-                    let buildId = null
-                    if (pack.package.build_id) {
-                        buildId = pack.package.build_id
+                let buildId = pack.package.build_id ? pack.package.build_id : null
+
+                if (pack.package.source) {
+                    let [name, version, release] = pack.package.source.split('-')
+                    if (!setPackages.has(name)) {
+                        packages.push(
+                            {
+                                name: name,
+                                version: version,
+                                release: release.replace('.src.rpm', ''),
+                                buildId: buildId
+                            }
+                        )
+                        setPackages.add(name)
                     }
-                    packages.push(
-                        {
-                            name: pack.package.name,
-                            version: pack.package.version,
-                            release: pack.package.release, buildId: buildId
-                        }
-                    )
+                } else if (pack.package.arch === 'src') {
+                    if (!setPackages.has(pack.package.name)) {
+                        packages.push(
+                            {
+                                name: pack.package.name,
+                                version: pack.package.version,
+                                release: pack.package.release,
+                                buildId: buildId
+                            }
+                        )
+                        setPackages.add(pack.package.name)
+                    }
                 }
             })
 
             if (packages.length === 0){
                 plan.packages.forEach(pack => {
                     if (!setPackages.has(pack.package.name)) {
-                        let buildId = null
-                        if (pack.package.build_id) {
-                            buildId = pack.package.build_id
-                        }
+                        let buildId = pack.package.build_id ? pack.package.build_id : null
+                        
                         packages.push(
                             {
                                 name: pack.package.name,
@@ -304,7 +316,6 @@ export default defineComponent({
             }
             return warning
         }
-
     }
 })
 </script>

--- a/src/pages/ReleaseFeed.vue
+++ b/src/pages/ReleaseFeed.vue
@@ -262,13 +262,13 @@ export default defineComponent({
                 let buildId = pack.package.build_id ? pack.package.build_id : null
 
                 if (pack.package.source) {
-                    let [name, version, release] = pack.package.source.split('-')
+                    let name = pack.package.source.split(`-${pack.package.version}-`)[0]
                     if (!setPackages.has(name)) {
                         packages.push(
                             {
                                 name: name,
-                                version: version,
-                                release: release.replace('.src.rpm', ''),
+                                version: pack.package.version,
+                                release: pack.package.release,
                                 buildId: buildId
                             }
                         )


### PR DESCRIPTION
Current we show src packages in the Packages column, but if we don't have a src package in a release, we show all of the release's packages, which makes the Release Feed page look very bulky. And if we have more than one src we show all of them, causing duplicates.