### PR TITLE
ALBS-753: Do not wait until build request is done to set reload to false

### DIFF
--- a/src/pages/Build.vue
+++ b/src/pages/Build.vue
@@ -913,8 +913,11 @@ export default defineComponent({
       }
     },
     loadBuildInfo (buildId) {
+      this.reload = false
+      if (!this.build) Loading.show()
       this.$api.get(`/builds/${buildId}/`)
         .then(response => {
+          this.reload = true
           let buildInfo = response.data
           if (!this.previousBuildInfo) {
             this.build = buildInfo


### PR DESCRIPTION
In case the API is running slow and requesting the build from the API takes more than a minute, we shouldn't reload until the first request is finished (successfully or not).