### PR TITLE
ALBS-1041: Updated mock binary build logs regex

### DIFF
--- a/src/pages/BuildLogs.vue
+++ b/src/pages/BuildLogs.vue
@@ -104,10 +104,10 @@
         return this.filterLogs(/(apt|build)-[\w.]+\.(cfg|conf|log)$/)
       },
       mockBinaryLogs () {
-        return this.filterLogs(/mock((-*\w)*?(?!srpm)\.\d+\.log|\.\d+\.cfg)$/)
+        return this.filterLogs(/mock(?:\w+)?(?:\.\d+)?\.\d+\.(?:cfg|log)$/)
       },
       mockSrpmLogs () {
-        return this.filterLogs(/mock(_\w+\.srpm\..*?\.log|\.srpm\.\d+\.cfg)$/)
+        return this.filterLogs(/mock(?:\w+)?\.srpm(?:\.\d+)?\.\d+\.(?:cfg|log)$/)
       },
       buildArtifacts () {
         return this.filterLogs(/modules/)


### PR DESCRIPTION
Now logs include the build id, see https://github.com/AlmaLinux/albs-node/commit/a9e648e832267d764fd7f3e70b3c214146798ee5

Can check the two updated regex here:
* binary: https://regexr.com/7abls
* srpm: https://regexr.com/7ablp

This way we ensure we pick up old and new build log names.