### PR TITLE
Update rpm_modules check in build pages

### DIFF
--- a/src/pages/Build.vue
+++ b/src/pages/Build.vue
@@ -1168,7 +1168,7 @@
         Loading.show()
 
         this.build.tasks.forEach((task) => {
-          if (task.rpm_modules) {
+          if (task.rpm_modules.length) {
             this.rpm_modules[`${task.platform.name}.${task.arch}`] =
               task.rpm_modules
           }


### PR DESCRIPTION
This fixes the issue where non modular builds are not properly rendered due to a wrong rpm_modules check.

Fixes: https://github.com/AlmaLinux/build-system/issues/151