### PR TITLE
Refactoring of Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,27 @@
-FROM almalinux:8
+FROM almalinux/9-base:latest
 
-RUN groupadd -g 1000 albs && \
-    useradd -u 1000 -g 1000 albs && \
-    curl https://nodejs.org/dist/v16.20.1/node-v16.20.1-linux-x64.tar.gz -o /root/node.tar.gz && \
-    cd /usr/local && \
-    tar --strip-components 1 -xzf /root/node.tar.gz
+ARG NODE_VER=16.20.2
+RUN <<EOT
+  set -ex
+  curl https://nodejs.org/dist/v${NODE_VER}/node-v${NODE_VER}-linux-x64.tar.gz | \
+    tar --strip-components 1 -C /usr/local -xzf-
+  rm -f /usr/local/{CHANGELOG.md,LICENSE,README.md}
+EOT
 
-RUN npm install -g -y @quasar/cli
-
+ARG UID=1000
+ARG GID=1000
+RUN groupadd -g ${GID} albs && useradd --create-home -u ${UID} -g ${GID} albs
 USER albs
+
+WORKDIR /home/albs
+
+COPY package-lock.json .
+RUN <<EOT
+  set -ex
+  npm ci --no-fund --no-audit --ignore-scripts --global-style
+  npm config set prefix "/home/albs/node_modules"
+  npm config set update-notifier false
+  rm -r .npm package-lock.json
+EOT
+
 WORKDIR /home/albs/code
-# CMD ["/bin/bash"]
-CMD ["npm", "run", "build"]
-# docker run --rm -it -v $(pwd):/code -p 8080:8080 7ce58f1d59e9

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 System overview
---- 
+---
 
-AlmaLinux Build System Frontend is designed to display the web UI of the Build System. ALBS Frontend has some functional features that help to work with the Build System: a user can choose what data to show and what data to send back to Web-Server. 
+AlmaLinux Build System Frontend is designed to display the web UI of the Build System. ALBS Frontend has some functional features that help to work with the Build System: a user can choose what data to show and what data to send back to Web-Server.
 Frontend is written on `vue 3` and `quasar 2`.
 
 Mentioned tools and libraries are required for ALBS Frontend to run in the current state:
-- node==v12.22.1 
+- node==v16.20
 
 
-Install the dependencies 
+Install the dependencies
 ---
 
 The following command installs all the needed packages as dependencies for Frontend to make sure it works as it must.
 
 ```
-npm install 
+npm install
 ```
 
 
@@ -22,7 +22,7 @@ Start the app in development mode (hot-code reloading, error reporting, etc.)
 ---
 
 The following command makes a development environment by putting all the files together and displaying how it looks on the host. If there are some changes in files, this command will rebuild and update the design immediately.
- 
+
 ```
 quasar dev
 ```
@@ -31,7 +31,7 @@ quasar dev
 Lint the files
 ---
 
-The following command is lint or linter. That is a tool to look through the code for programming errors, bugs, security issues, etc. So this command checks all the Frontend's files to see if there are any mistakes or complications. 
+The following command is lint or linter. That is a tool to look through the code for programming errors, bugs, security issues, etc. So this command checks all the Frontend's files to see if there are any mistakes or complications.
 
 ```
 npm run lint
@@ -53,12 +53,12 @@ Customize the configuration
 See [Configuring quasar.conf.js](https://v2.quasar.dev/quasar-cli/quasar-conf-js).
 
 
-Running docker-compose 
+Running docker-compose
 ---
 
 ALBS Frontend doesn't have its own `docker-compose.yml` file. So if you want to run Frontend, consider using the `docker-compose.yml` file from [ALBS Web-Server](https://github.com/AlmaLinux/albs-web-server).
 
 
-Reporting issues 
+Reporting issues
 ---
 All issues should be reported to the [Build System project](https://github.com/AlmaLinux/build-system).


### PR DESCRIPTION
- Switch to Almalinux 9
- Use `npm ci` to install dependencies from `package-lock.json`
- Store `node_modules` in the image (in `/home/albs`)

Resolves: AlmaLinux/build-system/issues/223