### PR TITLE
Fix release packages button in errata interface

### DIFF
--- a/src/components/ErrataInfo.vue
+++ b/src/components/ErrataInfo.vue
@@ -1022,17 +1022,18 @@
           }
         })
         if (build_tasks.length) {
-          let request_body = {
+          let requestBody = {
             builds: Array.from(builds),
             build_tasks: build_tasks,
+            // product_id should not be hardcoded
             product_id: 1, //AlmaLinux product
             platform_id: this.advisory.platform_id,
             reference_platform_id: this.advisory.platform_id,
           }
-          request_body = JSON.stringify(request_body)
+          requestBody = JSON.stringify(requestBody)
           this.$router.push({
             name: 'ErrataRelease',
-            params: {request_body},
+            query: {requestBody},
           })
         } else {
           Notify.create({

--- a/src/pages/ErrataRelease.vue
+++ b/src/pages/ErrataRelease.vue
@@ -8,17 +8,16 @@
 import { defineComponent } from 'vue'
 import PackageLocationSelectionForm from 'components/PackageLocationSelectionForm.vue'
 import { Notify } from 'quasar'
+import { useRoute } from 'vue-router'
 
 export default defineComponent({
-    props: {
-        request_body: String
-    },
     created () {
         this.createRelease()
     },
     methods: {
         createRelease() {
-            let data = JSON.parse(this.request_body)
+            const route = useRoute()
+            let data = JSON.parse(route.query.requestBody)
             this.$api.post(`/releases/new/`, data)
             .then(response => {
                 this.$refs.packageLocationSelectionForm.createTable(response.data)

--- a/src/pages/ErrataRelease.vue
+++ b/src/pages/ErrataRelease.vue
@@ -1,41 +1,40 @@
 <template>
-    <div class="q-pa-md">
-        <package-location-selection-form ref="packageLocationSelectionForm"/>
-    </div>
+  <div class="q-pa-md">
+    <package-location-selection-form ref="packageLocationSelectionForm" />
+  </div>
 </template>
 
 <script>
-import { defineComponent } from 'vue'
-import PackageLocationSelectionForm from 'components/PackageLocationSelectionForm.vue'
-import { Notify } from 'quasar'
-import { useRoute } from 'vue-router'
+  import {defineComponent} from 'vue'
+  import PackageLocationSelectionForm from 'components/PackageLocationSelectionForm.vue'
+  import {Notify} from 'quasar'
+  import {useRoute} from 'vue-router'
 
-export default defineComponent({
-    created () {
-        this.createRelease()
+  export default defineComponent({
+    created() {
+      this.createRelease()
     },
     methods: {
-        createRelease() {
-            const route = useRoute()
-            let data = JSON.parse(route.query.requestBody)
-            this.$api.post(`/releases/new/`, data)
-            .then(response => {
-                this.$refs.packageLocationSelectionForm.createTable(response.data)
+      createRelease() {
+        const route = useRoute()
+        let data = JSON.parse(route.query.requestBody)
+        this.$api
+          .post(`/releases/new/`, data)
+          .then((response) => {
+            this.$refs.packageLocationSelectionForm.createTable(response.data)
+          })
+          .catch((error) => {
+            Notify.create({
+              message: `${error.response.status}: ${error.response.statusText}`,
+              type: 'negative',
+              actions: [{label: 'Dismiss', color: 'white', handler: () => {}}],
             })
-            .catch(error => {
-                Notify.create({
-                    message: `${error.response.status}: ${error.response.statusText}`,
-                    type: 'negative',
-                    actions: [
-                        { label: 'Dismiss', color: 'white', handler: () => {} }
-                    ]
-                })
-                this.$router.go(-1)
-            })
-        }
+            this.$router.go(-1)
+          })
+      },
     },
     components: {
-        PackageLocationSelectionForm
-    }
-})
+      PackageLocationSelectionForm,
+    },
+  })
 </script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -132,7 +132,6 @@ const routes = [
         name: 'ErrataRelease',
         meta: {requiresAuth: true},
         component: () => import('pages/ErrataRelease.vue'),
-        props: (route) => ({...route.params}),
       },
       {
         path: 'release-feed',


### PR DESCRIPTION
`ErrataRelease` page now takes data in the query to later on be passed on to `releases/new` endpoint.

Fixes: https://github.com/AlmaLinux/build-system/issues/380