### PR TITLE
Fix errata output error caused by race condition

### DIFF
--- a/src/components/ErrataInfo.vue
+++ b/src/components/ErrataInfo.vue
@@ -815,7 +815,8 @@
         return description && description !== this.advisory.original_description
       },
       platformName(id) {
-        return this.platforms.find((platform) => platform.value == id).label
+        const platform = this.platforms.find((platform) => platform.value == id)
+        return platform ? platform.label : ''
       },
       cveRows(refs) {
         return refs.filter((ref) => ref.cve)

--- a/src/pages/ErrataFeed.vue
+++ b/src/pages/ErrataFeed.vue
@@ -532,7 +532,8 @@
         return advisory.title ? advisory.title : advisory.original_title
       },
       platformName(id) {
-        return this.platforms.find((platform) => platform.value == id).label
+        const platform = this.platforms.find((platform) => platform.value == id)
+        return platform ? platform.label : ''
       },
     },
     components: {


### PR DESCRIPTION
`this.platforms` is a computed value and may be empty when `platformName()` is executed, which can result in accessing a non-existent `label` property.

This fix unsure that matched platform exists before accessing it, preventing UI breakage.

Fixes: https://github.com/AlmaLinux/build-system/issues/430