### PR TITLE
Send build_id in errata packages when creating erratas

### DIFF
--- a/src/pages/CreateErrata.vue
+++ b/src/pages/CreateErrata.vue
@@ -705,6 +705,7 @@
               epoch: pkg.epoch,
               arch: pkg.arch,
               reboot_suggested: pkg.reboot_suggested,
+              build_id: pkg.build_id,
             })
           }
         })


### PR DESCRIPTION
Fixes: https://github.com/AlmaLinux/build-system/issues/378
Fixes: https://github.com/AlmaLinux/build-system/issues/415

This is the frontend side of https://github.com/AlmaLinux/albs-web-server/pull/1115