### PR TITLE
Add prev/next navigation to build and log pages

### DIFF
--- a/src/pages/Build.vue
+++ b/src/pages/Build.vue
@@ -5,12 +5,36 @@
 
     <q-card flat style="max-width: 100%; min-width: 0">
       <q-card-section class="text-h6 text-center">
-        <router-link :to="{path: `/build/${build.id}`}">
-          Build {{ build.id }}
-        </router-link>
-        created by
-        <a :href="`mailto:${build.owner.email}`">{{ build.owner.username }}</a>
-        at {{ buildCreatedTime }}
+        <div class="row items-center justify-center q-gutter-sm">
+          <q-btn
+            flat
+            dense
+            no-caps
+            text-color="primary"
+            icon="navigate_before"
+            label="Previous"
+            :disable="!adjacentBuilds.prev"
+            @click="$router.push(`/build/${adjacentBuilds.prev}`)"
+          />
+          <span>
+            <router-link :to="{path: `/build/${build.id}`}">
+              Build {{ build.id }}
+            </router-link>
+            created by
+            <a :href="`mailto:${build.owner.email}`">{{ build.owner.username }}</a>
+            at {{ buildCreatedTime }}
+          </span>
+          <q-btn
+            flat
+            dense
+            no-caps
+            text-color="primary"
+            icon-right="navigate_next"
+            label="Next"
+            :disable="!adjacentBuilds.next"
+            @click="$router.push(`/build/${adjacentBuilds.next}`)"
+          />
+        </div>
       </q-card-section>
 
       <q-card-section>
@@ -810,6 +834,7 @@
         previousBuildInfo: null,
         previousProducts: null,
         hasSrcArch: false,
+        adjacentBuilds: {prev: null, next: null},
       }
     },
     computed: {
@@ -945,6 +970,7 @@
     },
     created() {
       this.loadBuildInfo(this.buildId)
+      this.checkAdjacentBuilds(this.buildId)
       // update the build state every minute
       this.refreshTimer = setInterval(() => {
         if (this.reload) {
@@ -966,6 +992,28 @@
     methods: {
       loadLinkedBuildInfo(params) {
         this.loadBuildInfo(params.buildId)
+        this.checkAdjacentBuilds(params.buildId)
+      },
+      checkAdjacentBuilds(id) {
+        const numId = parseInt(id)
+        this.probeAdjacentBuild(numId, numId - 1, 'prev')
+        this.probeAdjacentBuild(numId, numId + 1, 'next')
+      },
+      probeAdjacentBuild(fromId, targetId, direction) {
+        if (targetId < 1) {
+          this.adjacentBuilds[direction] = false
+          return
+        }
+        // Ignore stale responses if the user navigated away mid-flight.
+        const isCurrent = () => parseInt(this.buildId) === fromId
+        this.$api
+          .get(`/builds/${targetId}/`)
+          .then(() => {
+            if (isCurrent()) this.adjacentBuilds[direction] = targetId
+          })
+          .catch(() => {
+            if (isCurrent()) this.adjacentBuilds[direction] = false
+          })
       },
       copyToClipboard: copyToClipboard,
       getTaskCSS: getTaskCSS,

--- a/src/pages/BuildItemInfo.vue
+++ b/src/pages/BuildItemInfo.vue
@@ -1,5 +1,15 @@
 <template>
   <div class="text-left bg-grey-2 shadow-2" style="padding-left: 5em">
+    <q-btn
+      flat
+      dense
+      no-caps
+      text-color="primary"
+      icon="navigate_before"
+      :to="`/build/${buildId}`"
+      label="Back to Build"
+      class="q-mt-sm"
+    />
     <p class="text-dark" style="font-size: 25px">
       {{ `${project_name} ${arch}` }}
     </p>


### PR DESCRIPTION
Adds "Previous" / "Next" buttons on the build detail page to jump to the adjacent build, and a "Back to Build" button on the build log page.

Each neighbouring build (id +/- 1) is checked against the builds API before enabling its button, so you won't hit dead ends at the first or last build.

Note: Navigation is by id +/- 1, so a deleted build will leave a gap. 

The "Back to Build" button is a bit of a bonus addition, happy to drop it if you'd rather keep this tightly scoped to the issue.

Fixes https://github.com/AlmaLinux/build-system/issues/510

<img width="1509" height="776" alt="image" src="https://github.com/user-attachments/assets/8c50cbf7-dc09-4f8d-92b2-160f887e64bc" />

<img width="1855" height="556" alt="image" src="https://github.com/user-attachments/assets/e1e9ac58-6b79-4081-a2a7-068792acb026" />
