### PR TITLE
Sign builds and pick them for a release right from the build feed

### DIFF
--- a/src/components/BuildFeedItem.vue
+++ b/src/components/BuildFeedItem.vue
@@ -14,16 +14,29 @@
           <thead>
             <tr>
               <th>
-                <q-btn
-                  color="tertiary"
-                  small
-                  flat
-                  class="q-pl-sm no-margin"
-                  icon="info"
-                  :to="{path: `/build/${build.id}`}"
-                  label="details"
-                  :id="`bfi-qb-details-${build.id}`"
-                />
+                <div class="row items-center no-wrap">
+                  <q-checkbox
+                    v-if="selectable"
+                    size="xs"
+                    class="q-ml-xs"
+                    :model-value="selected"
+                    :disable="!releasable"
+                    :id="`bfi-qc-release-${build.id}`"
+                    @update:model-value="$emit('toggleSelect', build)"
+                  >
+                    <q-tooltip> {{ selectionTooltip }} </q-tooltip>
+                  </q-checkbox>
+                  <q-btn
+                    color="tertiary"
+                    small
+                    flat
+                    class="q-pl-sm no-margin"
+                    icon="info"
+                    :to="{path: `/build/${build.id}`}"
+                    label="details"
+                    :id="`bfi-qb-details-${build.id}`"
+                  />
+                </div>
               </th>
               <template v-for="platform in buildPlatforms">
                 <th
@@ -64,12 +77,39 @@
         <br />
         at {{ buildCreatedTime }}
       </div>
-      <div class="q-pt-sm q-pl-md q-pb-md" v-if="build.releaseStatus">
-        <q-skeleton style="width: 100px" v-if="loading" type="text" />
-        <div v-else>
+    </q-card-section>
+    <q-card-section
+      v-if="build.releaseStatus || showSignButton"
+      class="no-padding row items-center"
+    >
+      <div class="col q-pt-sm q-pl-md q-pb-md">
+        <q-skeleton
+          style="width: 100px"
+          v-if="loading && build.releaseStatus"
+          type="text"
+        />
+        <div v-else-if="build.releaseStatus">
           <span class="text-bold"> Release status: </span>
           <span> {{ build.releaseStatus }} </span>
         </div>
+      </div>
+      <div
+        class="col-auto row items-center q-pt-sm q-pr-md q-pb-md"
+        v-if="showSignButton"
+      >
+        <q-btn
+          dense
+          no-caps
+          size="sm"
+          color="primary"
+          icon="lock"
+          label="Sign"
+          class="q-px-sm"
+          :id="`bfi-qb-sign-${build.id}`"
+          @click="$emit('sign', build)"
+        >
+          <q-tooltip> {{ signTooltip }} </q-tooltip>
+        </q-btn>
       </div>
     </q-card-section>
   </q-card>
@@ -79,15 +119,60 @@
   import {defineComponent} from 'vue'
   import {BuildStatus} from '../constants.js'
   import BuildRef from 'components/BuildRef.vue'
-  import {getTaskCSS, nsvca, sortByArches} from '../utils'
+  import {
+    getTaskCSS,
+    isBuildFinished,
+    isBuildSignable,
+    isBuildSigned,
+    lastSignStatus,
+    nsvca,
+    sortByArches,
+  } from '../utils'
+  import {SignStatus} from '../constants.js'
 
   export default defineComponent({
     name: 'BuildFeedItem',
     props: {
       build: Object,
       loading: Boolean,
+      selected: Boolean,
+      selectable: Boolean,
     },
+    emits: ['sign', 'toggleSelect'],
     computed: {
+      buildFinished() {
+        return isBuildFinished(this.build)
+      },
+      buildSigned() {
+        return isBuildSigned(this.build)
+      },
+      // Signing is only offered for builds that still need it: never signed,
+      // or the previous attempt failed. Signed, released and currently
+      // being signed builds have nothing left to do.
+      showSignButton() {
+        return (
+          this.$store.getters.isAuthenticated && isBuildSignable(this.build)
+        )
+      },
+      // A build can only be put into a release once it is built and signed,
+      // the very same conditions the release build selector enforces.
+      releasable() {
+        return this.buildFinished && this.buildSigned
+      },
+      signTooltip() {
+        return lastSignStatus(this.build) === SignStatus.FAILED
+          ? `Signing of build ${this.build.id} failed, click to sign it again`
+          : `Sign build ${this.build.id}`
+      },
+      selectionTooltip() {
+        if (!this.buildFinished) {
+          return `Build ${this.build.id} is not finished yet and cannot be released`
+        }
+        if (!this.buildSigned) {
+          return `Build ${this.build.id} is not signed and cannot be released`
+        }
+        return `Select build ${this.build.id} for a release`
+      },
       buildPlatforms() {
         let platformsNames = new Set()
         let platforms = []

--- a/src/components/BuildSelectionForm.vue
+++ b/src/components/BuildSelectionForm.vue
@@ -239,6 +239,10 @@
       releasePlatform: Object,
       releseProduct: Object,
       releaseId: Number,
+      preselectedBuildIds: {
+        type: Array,
+        default: () => [],
+      },
     },
     emits: ['nextStep', 'saveState'],
     data() {
@@ -286,7 +290,47 @@
         })
       },
     },
+    mounted() {
+      if (this.preselectedBuildIds.length) {
+        this.loadPreselectedBuilds()
+      }
+    },
     methods: {
+      // Adds the builds selected in the build feed to the release. They are
+      // loaded one by one, so that every build goes through the very same
+      // checks as a manually added one.
+      async loadPreselectedBuilds() {
+        for (const buildId of this.preselectedBuildIds) {
+          try {
+            await this.loadBuildInfo(buildId)
+          } catch (error) {
+            this.loading = false
+          }
+        }
+        this.preselectPlatform()
+      },
+      // Picks the platform of the added builds, there is nothing to choose
+      // from when all of them were built for the same one.
+      preselectPlatform() {
+        if (this.platform || !this.builds.length) return
+
+        let platforms = {}
+        this.builds.forEach((build) => {
+          build.tasks.forEach((task) => {
+            platforms[task.platform.name] = task.platform
+          })
+        })
+        let names = Object.keys(platforms)
+        if (names.length !== 1) return
+
+        let platform = platforms[names[0]]
+        this.platform = {
+          label: platform.name,
+          value: platform.name,
+          description: platform.arch_list.join(', '),
+          id: platform.id,
+        }
+      },
       productFilter(val, update, abort) {
         update(() => {
           const needle = val.toLocaleLowerCase()
@@ -332,7 +376,7 @@
         if (this.loading) return
 
         this.loading = true
-        this.$api
+        return this.$api
           .get(`/builds/${buildId}/`)
           .then((response) => {
             this.loading = false

--- a/src/components/SignBuildDialog.vue
+++ b/src/components/SignBuildDialog.vue
@@ -1,0 +1,132 @@
+<template>
+  <q-dialog v-model="show">
+    <q-card style="width: 400px" v-if="build">
+      <q-card-section>
+        <div class="text-h6">Sign build {{ build.id }}</div>
+      </q-card-section>
+      <q-form @submit="signBuild">
+        <q-card-section>
+          <q-select
+            v-model="current_sign"
+            label="Choose PGP key"
+            :rules="[(val) => !!val || 'PGP key is required']"
+            :options="existingKeys"
+            :loading="keysLoad"
+            id="sbd-qs-key"
+          />
+          <span v-if="preselectedKeyName" class="text-caption text-grey-7">
+            Pre-selected default key: {{ preselectedKeyName }}
+          </span>
+          <span v-if="!testingCompleted" class="text-negative">
+            <br />
+            <b>Warning:</b> the build testing is not finished yet. Are you sure
+            you want to sign it?
+          </span>
+        </q-card-section>
+        <q-card-actions align="right">
+          <q-btn
+            flat
+            text-color="primary"
+            label="Sign"
+            style="width: 150px"
+            :loading="loading"
+            type="submit"
+            id="sbd-qb-sign"
+          />
+          <q-btn
+            flat
+            text-color="negative"
+            label="Cancel"
+            v-close-popup
+            @click="current_sign = null"
+          />
+        </q-card-actions>
+      </q-form>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script>
+  import {defineComponent} from 'vue'
+  import {Notify} from 'quasar'
+  import {defaultSignKey, isBuildTestingCompleted} from '../utils'
+
+  export default defineComponent({
+    name: 'sign-build-dialog',
+    emits: ['signed'],
+    data() {
+      return {
+        show: false,
+        build: null,
+        current_sign: null,
+        preselectedKeyName: null,
+        loading: false,
+        keysLoad: false,
+      }
+    },
+    computed: {
+      existingKeys() {
+        return this.$store.state.keys.keys.map((key) => {
+          return {label: key.name, value: key.id}
+        })
+      },
+      testingCompleted() {
+        return isBuildTestingCompleted(this.build)
+      },
+    },
+    methods: {
+      open(build) {
+        this.build = build
+        this.current_sign = null
+        this.preselectedKeyName = null
+        this.show = true
+        if (this.$store.state.keys.keys.length) {
+          this.applyDefaultKey()
+          return
+        }
+        this.keysLoad = true
+        this.$store.dispatch('keys/loadKeysList').finally(() => {
+          this.keysLoad = false
+          this.applyDefaultKey()
+        })
+      },
+      applyDefaultKey() {
+        let key = defaultSignKey(this.build, this.$store.state.keys.keys)
+        if (!key) {
+          return
+        }
+        this.current_sign = {label: key.name, value: key.id}
+        this.preselectedKeyName = key.name
+      },
+      signBuild() {
+        this.loading = true
+        let buildId = this.build.id
+        let request_body = {
+          build_id: buildId,
+          sign_key_id: this.current_sign.value,
+        }
+        this.$api
+          .post('/sign-tasks/', request_body)
+          .then((response) => {
+            this.loading = false
+            this.show = false
+            this.current_sign = null
+            this.$emit('signed', {buildId: buildId, signTask: response.data})
+            Notify.create({
+              message: `Build ${buildId} is queued for signing`,
+              type: 'positive',
+              actions: [{label: 'Dismiss', color: 'white', handler: () => {}}],
+            })
+          })
+          .catch((error) => {
+            this.loading = false
+            Notify.create({
+              message: error.response.data.detail,
+              type: 'negative',
+              actions: [{label: 'Dismiss', color: 'white', handler: () => {}}],
+            })
+          })
+      },
+    },
+  })
+</script>

--- a/src/pages/Build.vue
+++ b/src/pages/Build.vue
@@ -193,9 +193,7 @@
                               name="key_off"
                               color="negative"
                             >
-                              <q-tooltip>
-                                Package is not notarized
-                              </q-tooltip>
+                              <q-tooltip> Package is not notarized </q-tooltip>
                             </q-icon>
                           </q-badge>
                         </div>
@@ -281,10 +279,10 @@
           <q-avatar icon="warning" color="negative" text-color="white" />
           Secure boot required: {{ missingSecureBootPackages.join(', ') }}
           <q-tooltip>
-            This build was queued without Secure Boot, but the platform
-            requires these package(s) to be built with Secure Boot enabled.
-            The produced artifacts will NOT be usable on Secure Boot
-            systems — please rebuild with the Secure Boot flag.
+            This build was queued without Secure Boot, but the platform requires
+            these package(s) to be built with Secure Boot enabled. The produced
+            artifacts will NOT be usable on Secure Boot systems — please rebuild
+            with the Secure Boot flag.
           </q-tooltip>
         </q-chip>
         <q-chip v-if="build.released">
@@ -302,8 +300,15 @@
         </q-chip>
       </q-card-section>
 
-      <q-card-section v-if="build.platform_flavors && build.platform_flavors.length">
-        <q-expansion-item label="Platform Flavors" expand-separator icon="local_offer" default-opened>
+      <q-card-section
+        v-if="build.platform_flavors && build.platform_flavors.length"
+      >
+        <q-expansion-item
+          label="Platform Flavors"
+          expand-separator
+          icon="local_offer"
+          default-opened
+        >
           <q-list dense separator>
             <q-item v-for="flavor in build.platform_flavors" :key="flavor.id">
               <q-item-section avatar>
@@ -900,11 +905,7 @@
         // queued with is_secure_boot=false. Empty list = nothing to warn
         // about. Used to render a red warning chip on completed/in-flight
         // builds.
-        if (
-          !this.build ||
-          !this.build.tasks ||
-          !this.build.tasks.length
-        ) {
+        if (!this.build || !this.build.tasks || !this.build.tasks.length) {
           return []
         }
         if (this.build.tasks[0].is_secure_boot) return []
@@ -914,12 +915,21 @@
           if (!url) return null
           try {
             const path = new URL(url).pathname
-            const last =
-              path.replace(/\/+$/, '').split('/').pop() || ''
-            return last.replace(/\.git$/, '').trim().toLowerCase() || null
+            const last = path.replace(/\/+$/, '').split('/').pop() || ''
+            return (
+              last
+                .replace(/\.git$/, '')
+                .trim()
+                .toLowerCase() || null
+            )
           } catch (_) {
             const last = String(url).split('/').pop() || ''
-            return last.replace(/\.git$/, '').trim().toLowerCase() || null
+            return (
+              last
+                .replace(/\.git$/, '')
+                .trim()
+                .toLowerCase() || null
+            )
           }
         }
         const offenders = new Set()

--- a/src/pages/Build.vue
+++ b/src/pages/Build.vue
@@ -432,7 +432,7 @@
             <q-item
               clickable
               v-close-popup
-              @click="sign_build = true"
+              @click="$refs.signBuildDialog.open(build)"
               v-if="buildFinished"
             >
               <q-item-section avatar>
@@ -700,46 +700,7 @@
         </q-card-actions>
       </q-card>
     </q-dialog>
-    <q-dialog v-model="sign_build">
-      <q-card style="width: 400px">
-        <q-card-section>
-          <div class="text-h6">Sign build</div>
-        </q-card-section>
-        <q-form @submit="signBuild">
-          <q-card-section>
-            <q-select
-              v-model="current_sign"
-              label="Choose PGP key"
-              :rules="[(val) => !!val || 'PGP key is required']"
-              :options="existingKeys"
-            />
-            <span v-if="!testingCompleted" class="text-negative">
-              <br />
-              <b>Warning:</b> the build testing is not finished yet. Are you
-              sure you want to sign it?
-            </span>
-          </q-card-section>
-          <q-card-actions align="right">
-            <q-btn
-              flat
-              text-color="primary"
-              label="Sign"
-              style="width: 150px"
-              :loading="loading"
-              type="submit"
-            >
-            </q-btn>
-            <q-btn
-              flat
-              text-color="negative"
-              label="Cancel"
-              v-close-popup
-              @click="current_sign = null"
-            />
-          </q-card-actions>
-        </q-form>
-      </q-card>
-    </q-dialog>
+    <sign-build-dialog ref="signBuildDialog" @signed="onBuildSigned" />
 
     <q-dialog v-model="sign_log">
       <q-card style="max-width: 900px">
@@ -778,12 +739,15 @@
   import BuildStatusCircle from 'components/BuildStatusCircle.vue'
   import ModuleYaml from 'components/ModuleYaml.vue'
   import MockOptionsShow from 'components/MockOptionsShow.vue'
+  import SignBuildDialog from 'components/SignBuildDialog.vue'
   import {BuildStatus, TestStatus, SignStatus} from '../constants.js'
   import {
     getTaskCSS,
     nsvca,
     copyToClipboard,
     deepDiff,
+    isBuildFinished,
+    isBuildTestingCompleted,
     isEmptyObject,
     sortByArches,
   } from '../utils'
@@ -803,7 +767,6 @@
         reload: true,
         refreshTimer: null,
         linked_builds: null,
-        sign_build: false,
         sign_log: false,
         add_to_product: false,
         remove_from_product: false,
@@ -813,7 +776,6 @@
         loading: false,
         buildLoad: false,
         moduleYamlLoad: false,
-        current_sign: null,
         current_product: null,
         mock_options: null,
         selectedTask: null,
@@ -853,11 +815,6 @@
           return this.build.products.find((p) => p.name === product.label)
         })
       },
-      existingKeys() {
-        return this.$store.state.keys.keys.map((key) => {
-          return {label: key.name, value: key.id}
-        })
-      },
       failedItems() {
         let rebuilt = false
         for (let task of this.build.tasks) {
@@ -869,28 +826,10 @@
         return rebuilt
       },
       testingCompleted() {
-        let testing_completed = true
-        for (let task of this.build.tasks) {
-          if (task.arch === 'src') continue
-          if (
-            task.status <= BuildStatus.COMPLETED ||
-            task.status == BuildStatus.TEST_CREATED ||
-            task.status == BuildStatus.TEST_STARTED
-          ) {
-            testing_completed = false
-            break
-          }
-        }
-        return testing_completed
+        return isBuildTestingCompleted(this.build)
       },
       buildFinished() {
-        let build_finished = true
-        for (let task of this.build.tasks) {
-          if (task.status < BuildStatus.COMPLETED) {
-            build_finished = false
-          }
-        }
-        return build_finished
+        return isBuildFinished(this.build)
       },
       buildTargets() {
         let targetsSet = new Set()
@@ -1195,32 +1134,8 @@
           })
         })
       },
-      signBuild() {
-        this.loading = true
-        let request_body = {
-          build_id: this.buildId,
-          sign_key_id: this.current_sign.value,
-        }
-        this.$api
-          .post('/sign-tasks/', request_body)
-          .then((response) => {
-            this.loading = false
-            this.signs = [response.data]
-            this.sign_build = false
-            Notify.create({
-              message: `Build ${this.buildId} is queued for signing`,
-              type: 'positive',
-              actions: [{label: 'Dismiss', color: 'white', handler: () => {}}],
-            })
-          })
-          .catch((error) => {
-            this.loading = false
-            Notify.create({
-              message: error.response.data.detail,
-              type: 'negative',
-              actions: [{label: 'Dismiss', color: 'white', handler: () => {}}],
-            })
-          })
+      onBuildSigned({signTask}) {
+        this.signs = [signTask]
       },
       showSignLog(sign) {
         this.sign_log = true
@@ -1580,6 +1495,7 @@
       BuildStatusCircle,
       ModuleYaml,
       MockOptionsShow,
+      SignBuildDialog,
     },
   })
 </script>

--- a/src/pages/BuildFeed.vue
+++ b/src/pages/BuildFeed.vue
@@ -6,7 +6,11 @@
         :key="build._id"
         :build="build"
         :loading="loading"
+        :selected="isSelected(build)"
+        :selectable="selectionMode"
         style="margin-top: 1vw"
+        @sign="onSign"
+        @toggleSelect="toggleSelect"
       />
     </div>
     <div class="q-pa-lg flex flex-center">
@@ -18,12 +22,61 @@
         id="bfe-qp-pagination"
       />
     </div>
+    <q-page-sticky
+      v-if="userAuthenticated()"
+      position="bottom-right"
+      :offset="[18, 18]"
+    >
+      <q-btn
+        v-if="!selectionMode"
+        no-caps
+        color="primary"
+        icon="playlist_add_check"
+        label="Select for release"
+        class="shadow-4"
+        id="bfe-qb-selection-mode"
+        @click="selectionMode = true"
+      >
+        <q-tooltip>
+          Pick the builds to release, then go to the release form
+        </q-tooltip>
+      </q-btn>
+      <div
+        v-else
+        class="row items-center q-gutter-sm q-pa-sm bg-white shadow-4 rounded-borders"
+      >
+        <span class="text-grey-8">
+          {{ selectedBuilds.length }} build(s) selected
+        </span>
+        <q-btn
+          flat
+          dense
+          no-caps
+          color="grey-8"
+          icon="close"
+          label="Cancel"
+          id="bfe-qb-cancel-selection"
+          @click="cancelSelection()"
+        />
+        <q-btn
+          no-caps
+          color="primary"
+          icon="cloud_upload"
+          label="Create release"
+          :disable="!selectedBuilds.length"
+          id="bfe-qb-create-release"
+          @click="toNewRelease()"
+        />
+      </div>
+    </q-page-sticky>
+    <sign-build-dialog ref="signBuildDialog" @signed="onBuildSigned" />
   </q-page>
 </template>
 
 <script>
   import {defineComponent, ref} from 'vue'
   import BuildFeedItem from 'components/BuildFeedItem.vue'
+  import SignBuildDialog from 'components/SignBuildDialog.vue'
   import {Loading, LocalStorage} from 'quasar'
   import {BuildStatus, SignStatus, TestStatus} from 'src/constants'
   import {parseJwt} from 'src/utils'
@@ -35,6 +88,12 @@
         builds: [],
         totalPages: ref(1),
         loading: false,
+        // Turned on by the "Select for release" button: only then the feed
+        // items show their selection checkbox.
+        selectionMode: false,
+        // Builds picked for a release, kept across pagination so that a
+        // release can be assembled from builds shown on different pages.
+        selectedBuilds: [],
       }
     },
     created() {
@@ -63,6 +122,41 @@
       '$route.query': 'updateFilter',
     },
     methods: {
+      userAuthenticated() {
+        return this.$store.getters.isAuthenticated
+      },
+      isSelected(build) {
+        return this.selectedBuilds.some((selected) => selected.id === build.id)
+      },
+      toggleSelect(build) {
+        if (this.isSelected(build)) {
+          this.selectedBuilds = this.selectedBuilds.filter(
+            (selected) => selected.id !== build.id
+          )
+        } else {
+          this.selectedBuilds.push(build)
+        }
+      },
+      cancelSelection() {
+        this.selectionMode = false
+        this.selectedBuilds = []
+      },
+      toNewRelease() {
+        this.$router.push({
+          path: '/release/create',
+          query: {builds: this.selectedBuilds.map((b) => b.id).join(',')},
+        })
+      },
+      onSign(build) {
+        this.$refs.signBuildDialog.open(build)
+      },
+      onBuildSigned({buildId, signTask}) {
+        let build = this.builds.find((item) => item.id === buildId)
+        if (!build) return
+
+        build.sign_tasks.push({id: signTask.id, status: signTask.status})
+        this.getReleaseStatus(build)
+      },
       checkAuthorize() {
         let user = LocalStorage.getItem('user')
         if (user) {
@@ -178,6 +272,7 @@
     },
     components: {
       BuildFeedItem,
+      SignBuildDialog,
     },
   })
 </script>

--- a/src/pages/CreateRelease.vue
+++ b/src/pages/CreateRelease.vue
@@ -1,250 +1,261 @@
 <template>
-    <q-stepper
-        v-model="currentStep"
-        ref="Releaser"
-        color="primary"
-        flat
-        class="q-pl-md"
-        style="margin-top: -90px"
+  <q-stepper
+    v-model="currentStep"
+    ref="Releaser"
+    color="primary"
+    flat
+    class="q-pl-md"
+    style="margin-top: -90px"
+  >
+    <q-step
+      name="buildSelection"
+      style="min-height: 200px"
+      title="Build selector"
     >
-        <q-step
-            name="buildSelection"
-            style="min-height: 200px;"
-            title="Build selector"
-        >    
-            <build-selection-form
-                v-if="(releaseId && release_id) || !releaseId"
-                :releaseBuilds="builds"
-                :releasePlatform="platform"
-                :releaseId="release_id"
-                :releseProduct="product"
-                :preselectedBuildIds="preselectedBuildIds"
-                @saveState="saveState"
-                @nextStep="onPackagesLocationSelector"
-                ref="buildSelectionForm"
-            />
-        </q-step>
+      <build-selection-form
+        v-if="(releaseId && release_id) || !releaseId"
+        :releaseBuilds="builds"
+        :releasePlatform="platform"
+        :releaseId="release_id"
+        :releseProduct="product"
+        :preselectedBuildIds="preselectedBuildIds"
+        @saveState="saveState"
+        @nextStep="onPackagesLocationSelector"
+        ref="buildSelectionForm"
+      />
+    </q-step>
 
-        <q-step
-            name="packageSelection"
-            style="min-height: 200px;"
-            title="Package location selector"
+    <q-step
+      name="packageSelection"
+      style="min-height: 200px"
+      title="Package location selector"
+    >
+      <package-location-selection-form ref="packageLocationSelectionForm" />
+    </q-step>
+
+    <template v-slot:navigation>
+      <q-stepper-navigation class="group justify-end">
+        <q-btn
+          @click="onPreviousStep"
+          flat
+          color="primary"
+          v-if="currentStep !== 'buildSelection'"
         >
-            <package-location-selection-form ref="packageLocationSelectionForm"/>
-        </q-step>
-        
-        <template v-slot:navigation>
-            <q-stepper-navigation class="group justify-end">
-                <q-btn @click="onPreviousStep"
-                        flat
-                        color="primary"
-                        v-if="currentStep !== 'buildSelection'">
-                    Back 
-                </q-btn>  
-            </q-stepper-navigation>
-        </template>
-    </q-stepper>
-
+          Back
+        </q-btn>
+      </q-stepper-navigation>
+    </template>
+  </q-stepper>
 </template>
 
 <script>
-import { defineComponent, ref } from 'vue'
-import { Loading, Notify } from 'quasar'
-import { getFromApi } from '../utils'
-import BuildSelectionForm from 'components/BuildSelectionForm.vue'
-import PackageLocationSelectionForm from 'components/PackageLocationSelectionForm.vue'
-import { BuildStatus } from 'src/constants'
+  import {defineComponent, ref} from 'vue'
+  import {Loading, Notify} from 'quasar'
+  import {getFromApi} from '../utils'
+  import BuildSelectionForm from 'components/BuildSelectionForm.vue'
+  import PackageLocationSelectionForm from 'components/PackageLocationSelectionForm.vue'
+  import {BuildStatus} from 'src/constants'
 
-export default defineComponent({
+  export default defineComponent({
     props: {
-        releaseId: String
+      releaseId: String,
     },
     data() {
-        return {
-            builds: ref([]),
-            platform: null,
-            product: null,
-            release_id: null,
-            currentStep: 'buildSelection',
-            plan: null
-        }
+      return {
+        builds: ref([]),
+        platform: null,
+        product: null,
+        release_id: null,
+        currentStep: 'buildSelection',
+        plan: null,
+      }
     },
     created() {
-        this.getRealese()
+      this.getRealese()
     },
     computed: {
-        // Builds picked in the build feed and passed over as
-        // ?builds=1,2,3 so they end up already added to the release.
-        preselectedBuildIds () {
-            if (this.releaseId || !this.$route.query.builds) return []
+      // Builds picked in the build feed and passed over as
+      // ?builds=1,2,3 so they end up already added to the release.
+      preselectedBuildIds() {
+        if (this.releaseId || !this.$route.query.builds) return []
 
-            return String(this.$route.query.builds)
-                .split(',')
-                .map(id => parseInt(id, 10))
-                .filter(id => !isNaN(id))
-        }
+        return String(this.$route.query.builds)
+          .split(',')
+          .map((id) => parseInt(id, 10))
+          .filter((id) => !isNaN(id))
+      },
     },
     methods: {
-        onPackagesLocationSelector (request_body) {
-            this.$refs.Releaser.next()
-            if (this.releaseId && (request_body.build_tasks === this.release.build_task_ids)) {
-                this.$refs.packageLocationSelectionForm.createTable(this.release)
-            } else {
-                this.release_id ? this.updateRelease(request_body) : this.createRelease(request_body) 
-            }
-        },
-        isSubArray (arr1, arr2 ) {
-            let flag = true
-            arr2.forEach( a2 => {
-                flag = arr1.indexOf(a2) === -1 ? false : true
-            })
-            return flag
-        },
-        parseBuilds () {
-            this.release.build_ids.forEach(async id => {
-                let build = await getFromApi(this.$api, `/builds/${id}`)
-                let successful = new Set()
-                let failed = new Set()
-                let options = {}
-                build.tasks.forEach(task => {
-                    switch (task.status) {
-                        case BuildStatus.COMPLETED:
-                            failed.has(task.index) ? build.warning = true : successful.add(task.index)
-                            
-                            if (options[task.index]){
-                                options[task.index].ids.push(task.id)
-                            } else {
-                                options[task.index] =  {
-                                    ids: [task.id],
-                                    ref: task.ref
-                                }
-                            }
-                            break;
-                        case BuildStatus.FAILED:
-                            failed.add(task.index)
-
-                            if (successful.has(task.index)) {
-                                build.warning = true
-                                successful.delete(task.index)
-                            } 
-                            break;
-                        default:
-                            break;
-                    }
-                })
-                build.selected = []
-                build.options = []
-                for (const index in options) {
-                    let opt = {
-                        value: +index,
-                        ids: options[index].ids,
-                        ref: options[index].ref,
-                        selected: this.isSubArray(this.release.build_task_ids, options[index].ids)
-                    }
-                    build.options.push(opt)
-                    if (opt.selected) build.selected.push(opt)
-                }
-                this.$refs.buildSelectionForm.builds.push(build)
-            })
-        },
-        getRealese () {
-            if (!this.releaseId) return
-
-            Loading.show()
-            this.$api.get(`/releases/${this.releaseId}/`)
-                .then(response => {
-                    Loading.hide()
-                    this.release = response.data
-                    this.plan = this.release.plan
-                    this.release_id = this.release.id
-                    this.platform = {
-                        label: this.release.platform.name,
-                        value: this.release.platform.name,
-                        description: this.release.platform.arch_list.join(', '),
-                        id: this.release.platform.id
-                    }
-                    this.product = {
-                        label: this.release.product.name,
-                        value: this.release.product.id,
-                        description: this.release.product.title
-                    }
-                    this.parseBuilds()
-                })
-                .catch(error => {
-                    Loading.hide()
-                    console.log(error)
-                    if (+String(error.response.status)[0] === 4 ){
-                        Notify.create({
-                            message: error.response.data.detail, type: 'negative',
-                            actions: [{ label: 'Dismiss', color: 'white', handler: () => {} }]
-                        })
-                    } else {
-                        Notify.create({
-                            message: `${error.response.status}: ${error.response.statusText}`,
-                            type: 'negative',
-                            actions: [
-                                { label: 'Dismiss', color: 'white', handler: () => {} }
-                            ]
-                        })
-                    }
-                })
-
-        },
-        createRelease (request_body) {
-            this.$api.post(`/releases/new/`, request_body)
-                .then(response => {
-                    this.$refs.packageLocationSelectionForm.createTable(response.data)
-                })
-                .catch(error => {
-                    console.log(error)
-                    Notify.create({
-                        message: `${error.response.status}: ${error.response.statusText}`,
-                        type: 'negative',
-                        actions: [
-                            { label: 'Dismiss', color: 'white', handler: () => {} }
-                        ]
-                    })
-                    this.onPreviousStep()
-                })
-        },
-        updateRelease (request_body) {
-            request_body.plan = this.plan
-            this.$api.put(`/releases/${this.release_id}/`, request_body)
-                .then(response => {
-                    this.$refs.packageLocationSelectionForm.createTable(response.data)
-                })
-                .catch(error => {
-                    console.log(error)
-                    Notify.create({
-                        message: `${error.response.status}: ${error.response.statusText}`,
-                        type: 'negative',
-                        actions: [
-                            { label: 'Dismiss', color: 'white', handler: () => {} }
-                        ]
-                    })
-                    this.onPreviousStep()
-                }) 
-        },
-        saveState (state){
-            this.builds = state.builds
-            this.platform = state.platform
-            this.product = state.product
-        },
-        onNextStep () {
-            this.$refs.Releaser.next()
-        },
-        onPreviousStep() {
-            if (this.currentStep === 'packageSelection'){
-                this.plan = this.$refs.packageLocationSelectionForm.getPlan()
-                this.release_id = this.$refs.packageLocationSelectionForm.releaseId
-            }
-            this.$refs.Releaser.previous()
+      onPackagesLocationSelector(request_body) {
+        this.$refs.Releaser.next()
+        if (
+          this.releaseId &&
+          request_body.build_tasks === this.release.build_task_ids
+        ) {
+          this.$refs.packageLocationSelectionForm.createTable(this.release)
+        } else {
+          this.release_id
+            ? this.updateRelease(request_body)
+            : this.createRelease(request_body)
         }
+      },
+      isSubArray(arr1, arr2) {
+        let flag = true
+        arr2.forEach((a2) => {
+          flag = arr1.indexOf(a2) === -1 ? false : true
+        })
+        return flag
+      },
+      parseBuilds() {
+        this.release.build_ids.forEach(async (id) => {
+          let build = await getFromApi(this.$api, `/builds/${id}`)
+          let successful = new Set()
+          let failed = new Set()
+          let options = {}
+          build.tasks.forEach((task) => {
+            switch (task.status) {
+              case BuildStatus.COMPLETED:
+                failed.has(task.index)
+                  ? (build.warning = true)
+                  : successful.add(task.index)
+
+                if (options[task.index]) {
+                  options[task.index].ids.push(task.id)
+                } else {
+                  options[task.index] = {
+                    ids: [task.id],
+                    ref: task.ref,
+                  }
+                }
+                break
+              case BuildStatus.FAILED:
+                failed.add(task.index)
+
+                if (successful.has(task.index)) {
+                  build.warning = true
+                  successful.delete(task.index)
+                }
+                break
+              default:
+                break
+            }
+          })
+          build.selected = []
+          build.options = []
+          for (const index in options) {
+            let opt = {
+              value: +index,
+              ids: options[index].ids,
+              ref: options[index].ref,
+              selected: this.isSubArray(
+                this.release.build_task_ids,
+                options[index].ids
+              ),
+            }
+            build.options.push(opt)
+            if (opt.selected) build.selected.push(opt)
+          }
+          this.$refs.buildSelectionForm.builds.push(build)
+        })
+      },
+      getRealese() {
+        if (!this.releaseId) return
+
+        Loading.show()
+        this.$api
+          .get(`/releases/${this.releaseId}/`)
+          .then((response) => {
+            Loading.hide()
+            this.release = response.data
+            this.plan = this.release.plan
+            this.release_id = this.release.id
+            this.platform = {
+              label: this.release.platform.name,
+              value: this.release.platform.name,
+              description: this.release.platform.arch_list.join(', '),
+              id: this.release.platform.id,
+            }
+            this.product = {
+              label: this.release.product.name,
+              value: this.release.product.id,
+              description: this.release.product.title,
+            }
+            this.parseBuilds()
+          })
+          .catch((error) => {
+            Loading.hide()
+            console.log(error)
+            if (+String(error.response.status)[0] === 4) {
+              Notify.create({
+                message: error.response.data.detail,
+                type: 'negative',
+                actions: [
+                  {label: 'Dismiss', color: 'white', handler: () => {}},
+                ],
+              })
+            } else {
+              Notify.create({
+                message: `${error.response.status}: ${error.response.statusText}`,
+                type: 'negative',
+                actions: [
+                  {label: 'Dismiss', color: 'white', handler: () => {}},
+                ],
+              })
+            }
+          })
+      },
+      createRelease(request_body) {
+        this.$api
+          .post(`/releases/new/`, request_body)
+          .then((response) => {
+            this.$refs.packageLocationSelectionForm.createTable(response.data)
+          })
+          .catch((error) => {
+            console.log(error)
+            Notify.create({
+              message: `${error.response.status}: ${error.response.statusText}`,
+              type: 'negative',
+              actions: [{label: 'Dismiss', color: 'white', handler: () => {}}],
+            })
+            this.onPreviousStep()
+          })
+      },
+      updateRelease(request_body) {
+        request_body.plan = this.plan
+        this.$api
+          .put(`/releases/${this.release_id}/`, request_body)
+          .then((response) => {
+            this.$refs.packageLocationSelectionForm.createTable(response.data)
+          })
+          .catch((error) => {
+            console.log(error)
+            Notify.create({
+              message: `${error.response.status}: ${error.response.statusText}`,
+              type: 'negative',
+              actions: [{label: 'Dismiss', color: 'white', handler: () => {}}],
+            })
+            this.onPreviousStep()
+          })
+      },
+      saveState(state) {
+        this.builds = state.builds
+        this.platform = state.platform
+        this.product = state.product
+      },
+      onNextStep() {
+        this.$refs.Releaser.next()
+      },
+      onPreviousStep() {
+        if (this.currentStep === 'packageSelection') {
+          this.plan = this.$refs.packageLocationSelectionForm.getPlan()
+          this.release_id = this.$refs.packageLocationSelectionForm.releaseId
+        }
+        this.$refs.Releaser.previous()
+      },
     },
     components: {
-        BuildSelectionForm,
-        PackageLocationSelectionForm
-    }
-})
-
+      BuildSelectionForm,
+      PackageLocationSelectionForm,
+    },
+  })
 </script>

--- a/src/pages/CreateRelease.vue
+++ b/src/pages/CreateRelease.vue
@@ -18,6 +18,7 @@
                 :releasePlatform="platform"
                 :releaseId="release_id"
                 :releseProduct="product"
+                :preselectedBuildIds="preselectedBuildIds"
                 @saveState="saveState"
                 @nextStep="onPackagesLocationSelector"
                 ref="buildSelectionForm"
@@ -70,6 +71,18 @@ export default defineComponent({
     },
     created() {
         this.getRealese()
+    },
+    computed: {
+        // Builds picked in the build feed and passed over as
+        // ?builds=1,2,3 so they end up already added to the release.
+        preselectedBuildIds () {
+            if (this.releaseId || !this.$route.query.builds) return []
+
+            return String(this.$route.query.builds)
+                .split(',')
+                .map(id => parseInt(id, 10))
+                .filter(id => !isNaN(id))
+        }
     },
     methods: {
         onPackagesLocationSelector (request_body) {

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -71,9 +71,7 @@ const routes = [
           // Platforms are needed so the Build page can detect packages
           // that should have been built with Secure Boot. The endpoint
           // is public, so it's loaded unconditionally.
-          store
-            .dispatch('platforms/loadPlatformList')
-            .catch(() => {})
+          store.dispatch('platforms/loadPlatformList').catch(() => {})
           if (store.getters.isUserValid) {
             store
               .dispatch('products/loadProductList')

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -27,10 +27,16 @@ const routes = [
         name: 'BuildFeed',
         component: () => import('pages/BuildFeed.vue'),
         beforeEnter(to, from, next) {
-          Promise.all([
+          let requests = [
             store.dispatch('users/loadUsersList'),
             store.dispatch('platforms/loadPlatformList'),
-          ]).finally(next)
+          ]
+          // Sign keys are needed by the sign dialog, which is available
+          // right from the feed for every finished build.
+          if (store.getters.isUserValid) {
+            requests.push(store.dispatch('keys/loadKeysList'))
+          }
+          Promise.all(requests).finally(next)
         },
         children: [
           {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-import {BuildStatus, BuildTaskRefType} from './constants'
+import {BuildStatus, BuildTaskRefType, SignStatus} from './constants'
 import {Notify} from 'quasar'
 
 /**
@@ -232,6 +232,135 @@ export function getTaskCSS(task) {
       break
   }
   return css
+}
+
+/**
+ * Returns true if every build task has finished, i.e. the build itself
+ * is not being built anymore.
+ *
+ * @param {Object} build - Build.
+ * @returns {Boolean}
+ */
+export function isBuildFinished(build) {
+  if (!build || !build.tasks) {
+    return false
+  }
+  return build.tasks.every((task) => task.status >= BuildStatus.COMPLETED)
+}
+
+/**
+ * Returns true if the testing stage is over for every non-src build task.
+ *
+ * @param {Object} build - Build.
+ * @returns {Boolean}
+ */
+export function isBuildTestingCompleted(build) {
+  if (!build || !build.tasks) {
+    return false
+  }
+  return build.tasks.every((task) => {
+    if (task.arch === 'src') {
+      return true
+    }
+    return (
+      task.status > BuildStatus.COMPLETED &&
+      task.status !== BuildStatus.TEST_CREATED &&
+      task.status !== BuildStatus.TEST_STARTED
+    )
+  })
+}
+
+/**
+ * Returns the status of the latest sign task of the build, or null when the
+ * build has never been sent for signing.
+ *
+ * @param {Object} build - Build.
+ * @returns {Number|null}
+ */
+export function lastSignStatus(build) {
+  if (!build || !build.sign_tasks || !build.sign_tasks.length) {
+    return null
+  }
+  let signTasks = build.sign_tasks
+  return signTasks[signTasks.length - 1].status
+}
+
+/**
+ * Returns true if the latest sign task of the build has succeeded.
+ *
+ * @param {Object} build - Build.
+ * @returns {Boolean}
+ */
+export function isBuildSigned(build) {
+  return lastSignStatus(build) === SignStatus.DONE
+}
+
+/**
+ * Returns true if the build is waiting to be signed: it is built, not
+ * released, and either was never sent for signing or the last attempt
+ * failed. A build that is signed, queued or being signed right now needs
+ * no signing action.
+ *
+ * @param {Object} build - Build.
+ * @returns {Boolean}
+ */
+export function isBuildSignable(build) {
+  if (!isBuildFinished(build) || build.released) {
+    return false
+  }
+  let status = lastSignStatus(build)
+  return status === null || status === SignStatus.FAILED
+}
+
+/**
+ * Returns the PGP key that should be pre-selected when signing the build.
+ *
+ * Sign keys are bound to products and platforms in the build system
+ * configuration, so that a build made for AlmaLinux 8 gets the AlmaLinux 8
+ * key pre-selected. Product keys take precedence, because community builds
+ * are always signed with the key of their own product.
+ *
+ * More than one key can be bound to the same platform (for instance both
+ * AlmaLinux-10 and AlmaLinux-10-EPEL-AltArch cover the AlmaLinux 10
+ * platforms) and the build system has no notion of a default one. In that
+ * case the oldest key wins, which is the main key of the distribution,
+ * so that the pre-selection does not depend on the order the API happens
+ * to return the keys in.
+ *
+ * @param {Object} build - Build.
+ * @param {Array} keys - Sign keys, as returned by the /sign-keys/ endpoint.
+ * @returns {Object|null}
+ */
+export function defaultSignKey(build, keys) {
+  if (!build || !keys || !keys.length) {
+    return null
+  }
+  let oldestFirst = keys
+    .filter((key) => key.active !== false)
+    .slice()
+    .sort((a, b) => a.id - b.id)
+  let productIds = new Set((build.products || []).map((product) => product.id))
+  if (productIds.size) {
+    let productKey = oldestFirst.find(
+      (key) => key.product_id && productIds.has(key.product_id)
+    )
+    if (productKey) {
+      return productKey
+    }
+  }
+  let platformIds = new Set(
+    (build.tasks || [])
+      .filter((task) => task.platform)
+      .map((task) => task.platform.id)
+  )
+  if (!platformIds.size) {
+    return null
+  }
+  return (
+    oldestFirst.find((key) =>
+      (key.platform_ids || []).some((id) => platformIds.has(id))
+    ) || null
+  )
 }
 
 export function pathJoin(parts) {


### PR DESCRIPTION
Signing a build and putting it into a release both required opening the build page first. Both actions are now available in the feed itself.

The sign dialog is extracted into a SignBuildDialog component shared by the build page and the feed. It pre-selects the PGP key bound to the build in the build system configuration: the product key for community builds, otherwise the key of the build platform, so an AlmaLinux 8 build gets the AlmaLinux 8 key. Several active keys can be bound to the same platform and there is no notion of a default one, so the oldest key wins to keep the pre-selection independent of the order the API returns.

Feed items show a Sign button only while signing is still pending: the build is finished, not released, and either was never signed or the last attempt failed.

The "Select for release" button turns on selection mode, which reveals a checkbox in the top left corner of every build card. The selection is kept across pagination, so a release can be assembled from builds listed on different pages, and it is handed over to the release form through a builds query parameter. Every build is then loaded by the build selector itself, going through the very same checks as a manually added one, and the platform is pre-selected when all of them share it. Builds that cannot be released, being unfinished or unsigned, cannot be selected.

Duplicated build state checks move from the build page to utils, so the page, the feed items and the sign dialog agree on them.